### PR TITLE
IEEE JBHI Citation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Aurora-BP Study and Dataset
 
-This repository contains sample code, sample data, and explanatory information for working with the **Aurora-BP dataset** released alongside the publication of the **Aurora-BP study**, i.e., Mieloszyk, Rebecca, et al. "[A Comparison of Wearable Tonometry, Photoplethysmography, and Electrocardiography for Cuffless Measurement of Blood Pressure in an Ambulatory Setting.](https://ieeexplore.ieee.org/document/9721156)" *IEEE Journal of Biomedical and Health Informatics* (2022).
+This repository contains sample code, sample data, and explanatory information for working with the **Aurora-BP dataset** released alongside the publication of the [**Aurora-BP study**](#citation).
 
 The dataset includes de-identified participant information, raw sensor data aligned with each measurement, and a wide variety of features derived from sensor data. The publishing of this dataset as well as the characterization of multiple feature groups across a broad population and multiple settings are intended to aid future cardiovascular research.
 
@@ -10,7 +10,7 @@ Note that the data contained in this repository represent a very small sample of
 
 If you use this repository, part or all of the full dataset, and/or our paper as part of your research, please refer to the dataset as the **Aurora-BP dataset** and cite the publication as follows:
 
-> Mieloszyk, Rebecca, et al. "[A Comparison of Wearable Tonometry, Photoplethysmography, and Electrocardiography for Cuffless Measurement of Blood Pressure in an Ambulatory Setting.](https://ieeexplore.ieee.org/document/9721156)" *IEEE Journal of Biomedical and Health Informatics* (2022)
+> R.J. Mieloszyk *et al.* "[A Comparison of Wearable Tonometry, Photoplethysmography, and Electrocardiography for Cuffless Measurement of Blood Pressure in an Ambulatory Setting](https://ieeexplore.ieee.org/document/9721156)," *IEEE Journal of Biomedical and Health Informatics*, vol. 26, no. 7, pp. 2864–2875 (2022).
 
 ## Navigation
 


### PR DESCRIPTION
## Changes:
* Updated IEEE JBHI article citation with full July 2022 issue details
* Replaced duplicate citation with link to citation section